### PR TITLE
Added prop for toolbar icon size

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ Other props supported by the `RichToolbar` component are:
     
     These provide options for styling action buttons.
 
+* `iconSize`
+    
+    Defines the size of the icon in pixels. Default is 50.
+
 * `renderAction`
 
 	Altenatively, you can provide a render function that will be used instead of the default, so you can fully control the tollbar design.

--- a/src/RichToolbar.js
+++ b/src/RichToolbar.js
@@ -110,16 +110,17 @@ export default class RichToolbar extends Component {
 
   _defaultRenderAction(action, selected) {
     const icon = this._getButtonIcon(action);
+    const { iconSize = 50 } = this.props
     return (
       <TouchableOpacity
           key={action}
           style={[
-            {height: 50, width: 50, justifyContent: 'center'},
+            {height: iconSize, width: iconSize, justifyContent: 'center'},
             selected ? this._getButtonSelectedStyle() : this._getButtonUnselectedStyle()
           ]}
           onPress={() => this._onPress(action)}
       >
-        {icon ? <Image source={icon} style={{tintColor: selected ? this.props.selectedIconTint : this.props.iconTint}}/> : null}
+        {icon ? <Image source={icon} style={{tintColor: selected ? this.props.selectedIconTint : this.props.iconTint, height: iconSize, width: iconSize}}/> : null}
       </TouchableOpacity>
     );
   }


### PR DESCRIPTION
Added prop for icon size on the toolbar. This makes it easier to adjust for different screen sizes.

![image](https://user-images.githubusercontent.com/1489169/74785362-29428580-5278-11ea-86ff-8c89afc78371.png)
