### PR TITLE
Add new functions for blur/focus that remember position and InsertText function

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The editor component. Simply place this component in your view hierarchy to rece
 	A boolean value that determines if a View container is wrapped around the WebView. The default value is true. If you are using your own View to wrap this library around, set this value to false. 
 	
 	
+
 `RichEditor` also has methods that can be used on its `ref` to  set:
 
 *  `setContentHTML(html:string)`
@@ -50,6 +51,8 @@ The editor component. Simply place this component in your view hierarchy to rece
 *  `setContentFocusHandler(handler: Function)`
 *  `blurContentEditor()`
 *  `focusContentEditor()`
+*  `blurKeepPosition()`
+*  `focusOnPreviousPosition()`
 
 This method registers a function that will get called whenver the cursor position changes or a change is made to the styling of the editor at the cursor's position., The callback will be called with an array of `actions` that are active at the cusor position, allowing a toolbar to respond to changes.
 
@@ -93,27 +96,26 @@ Other props supported by the `RichToolbar` component are:
   	* `actions.insertBulletsList`
   	* `actions.insertOrderedList`
   	* `actions.insertLink`
-  	
+  
 * `onPressAddImage`
 
     Functions called when the `addImage` actions are tapped. 
-        
+    
 * `selectedButtonStyle`
 * `iconTint`
 * `selectedIconTint`
 * `unselectedButtonStyle`
-    
+  
     These provide options for styling action buttons.
 
 * `iconSize`
-    
+  
     Defines the size of the icon in pixels. Default is 50.
 
 * `renderAction`
 
-	Altenatively, you can provide a render function that will be used instead of the default, so you can fully control the tollbar design.
-	
-	
+  Altenatively, you can provide a render function that will be used instead of the default, so you can fully control the tollbar design.
+
 * `iconMap` 
 
 	`RichTextToolbar` comes with default icons for the default actions it renders. To override those, or to add icons for non-default actions, provide them in a dictionary to this prop.

--- a/src/RichEditor.js
+++ b/src/RichEditor.js
@@ -221,8 +221,20 @@ export default class RichTextEditor extends Component {
         this._sendAction(actions.content, 'focus');
     }
 
+    blurKeepPosition() {
+        this._sendAction(actions.content, 'blurKeepPosition');
+    }
+
+    focusOnPreviousPosition() {
+        this._sendAction(actions.content, 'focusOnPreviousPosition');
+    }
+
     insertImage(attributes) {
         this._sendAction(actions.insertImage, 'result', attributes);
+    }
+
+    insertText(text) {
+        this._sendAction(actions.text, 'result', text);
     }
 
     init() {

--- a/src/const.js
+++ b/src/const.js
@@ -22,6 +22,7 @@ export const actions = {
     insertOrderedList: 'orderedList',
     insertLink: 'link',
     insertImage: 'image',
+    insertText: 'text',
     setSubscript: 'subscript',
     setSuperscript: 'superscript',
     setStrikethrough: 'strikeThrough',


### PR DESCRIPTION
# Problem
Github issue: https://github.com/stulip/react-native-pell-rich-editor/issues/58
I was facing a problem to introduce text from outside buttons/elements to the Editor. Like an emoji selector or predefined user values.

That requires to move the focus outside of the editor, allow the user to select what to insert, insert the element back and restore focus.

The current blur/focus functions do not allow to do it, from my own tests, on Android focus puts the cursor at the end, and iOS puts the cursor at the front. None of them is valid in my case of use.

# Solution proposed on this PR
Created a new blur function `blurKeepPosition` that will save the current cursor position before executing the blur action. And another one called `focusOnPreviousPosition` to use the previously saved pointer in order to put the cursor back at the same position.

Combined with these functions I have added another one called: `insertText(text)` that will insert the provided `text` string in the document.

# Example
```javascript
const openEmojiSelector = useCallback(() => {
    // Blur editor and remember position
    richText.current?.blurKeepPosition()
    // Whatever local function/component you need to manage
    setEmojiSelectorVisible(true)
  }, [richText])

const insertEmoji = useCallback((text) => {
    // Focus first to the saved position, so any text insert will be added to this position
    richText.current?.focusOnPreviousPosition()
    // Insert text where the cursor is placed
    richText.current?.insertText(text)
    setEmojiSelectorVisible(false)
  }, [])
```