### PR TITLE
Add Custom actions to the Toolbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # React Native Pell Rich Text Editor
 
-
 [![NPM](https://img.shields.io/npm/v/react-native-pell-rich-editor.svg)](https://www.npmjs.com/package/react-native-pell-rich-editor)
 
-------
+---
 
 > A fully functional Rich Text Editor for both Android and iOS
 
@@ -15,112 +14,133 @@ npm i react-native-pell-rich-editor
 
 Also, follow instructions [here](https://github.com/react-native-community/react-native-webview) to add the native `react-native-webview` dependency.
 
-* [Example](./examples)
+-   [Example](./examples)
 
 ## `RichEditor`
+
 The editor component. Simply place this component in your view hierarchy to receive a fully functional Rich text Editor.
 
 `RichEditor` takes the following optional props:
 
-* `placeholder`
+-   `placeholder`
 
     Wrap the editor content placeholder
 
-* `initialContentHTML`
+-   `initialContentHTML`
 
-	HTML that will be rendered in the content section on load.
+        	HTML that will be rendered in the content section on load.
 
-* `editorInitializedCallback `
+-   `editorInitializedCallback`
 
-	A function that will be called when the editor has been initialized.
-	
-* `editorStyle`
+        	A function that will be called when the editor has been initialized.
 
-	Styling for container or for Rich Editor more dark or light settings
+-   `editorStyle`
 
-* `useContainer`
+        	Styling for container or for Rich Editor more dark or light settings
 
-	A boolean value that determines if a View container is wrapped around the WebView. The default value is true. If you are using your own View to wrap this library around, set this value to false. 
-	
-	
-`RichEditor` also has methods that can be used on its `ref` to  set:
+-   `useContainer`
 
-*  `setContentHTML(html:string)`
-*  `insertImage(url:string) `
-*  `setContentFocusHandler(handler: Function)`
-*  `blurContentEditor()`
-*  `focusContentEditor()`
+        	A boolean value that determines if a View container is wrapped around the WebView. The default value is true. If you are using your own View to wrap this library around, set this value to false.
+
+`RichEditor` also has methods that can be used on its `ref` to set:
+
+-   `setContentHTML(html:string)`
+-   `insertImage(url:string)`
+-   `setContentFocusHandler(handler: Function)`
+-   `blurContentEditor()`
+-   `focusContentEditor()`
 
 This method registers a function that will get called whenver the cursor position changes or a change is made to the styling of the editor at the cursor's position., The callback will be called with an array of `actions` that are active at the cusor position, allowing a toolbar to respond to changes.
 
-*  `registerToolbar(listener: Function)` 
-
-
+-   `registerToolbar(listener: Function)`
 
 ### Example Usage:
 
 ```javascript
 <RichEditor
-  ref={(r) => this.richtext = r}
-  initialContentHTML={'Hello <b>World</b> <p>this is a new paragraph</p> <p>this is another new paragraph</p>'}
-  editorInitializedCallback={() => this.onEditorInitialized()}
+    ref={(r) => (this.richtext = r)}
+    initialContentHTML={'Hello <b>World</b> <p>this is a new paragraph</p> <p>this is another new paragraph</p>'}
+    editorInitializedCallback={() => this.onEditorInitialized()}
 />
 ```
 
 ![](readme/editor.jpg)
 
-
 ## `RichToolbar`
 
 This is a Component that provides a toolbar for easily controlling an editor. It is designed to be used together with a `RichEditor` component.
 
-The `RichToolbar` has one required property: 
+The `RichToolbar` has one required property:
 
-* `getEditor()`
+-   `getEditor()`
 
-Which must provide a **function** that returns a `ref` to a `RichEditor` component. 
+Which must provide a **function** that returns a `ref` to a `RichEditor` component.
 
 This is because the `ref` is not created until after the first render, before which the toolbar is rendered. This means that any `ref` passed directly will inevitably be passed as `undefined`.
 
 Other props supported by the `RichToolbar` component are:
 
-* `actions`
+-   `actions`
 
-	An `array` of `actions` to be provided by this toolbar. The default actions are: 
-	* `actions.insertImage`
-  	* `actions.setBold`
-  	* `actions.setItalic`
-  	* `actions.insertBulletsList`
-  	* `actions.insertOrderedList`
-  	* `actions.insertLink`
-  	
-* `onPressAddImage`
+        	An `array` of `actions` to be provided by this toolbar. The default actions are:
+        	* `actions.insertImage`
+        * `actions.setBold`
+        * `actions.setItalic`
+        * `actions.insertBulletsList`
+        * `actions.insertOrderedList`
+        * `actions.insertLink`
 
-    Functions called when the `addImage` actions are tapped. 
-        
-* `selectedButtonStyle`
-* `iconTint`
-* `selectedIconTint`
-* `unselectedButtonStyle`
-    
+-   `onPressAddImage`
+
+    Functions called when the `addImage` actions are tapped.
+
+-   `selectedButtonStyle`
+-   `iconTint`
+-   `selectedIconTint`
+-   `unselectedButtonStyle`
+
     These provide options for styling action buttons.
 
-* `iconSize`
-    
+-   `iconSize`
+
     Defines the size of the icon in pixels. Default is 50.
 
-* `renderAction`
+-   `renderAction`
 
-	Altenatively, you can provide a render function that will be used instead of the default, so you can fully control the tollbar design.
-	
-	
-* `iconMap` 
+        	Altenatively, you can provide a render function that will be used instead of the default, so you can fully control the tollbar design.
 
-	`RichTextToolbar` comes with default icons for the default actions it renders. To override those, or to add icons for non-default actions, provide them in a dictionary to this prop.
-	
-	
+-   `iconMap`
+
+        	`RichTextToolbar` comes with default icons for the default actions it renders. To override those, or to add icons for non-default actions, provide them in a dictionary to this prop.
+
 ### Example Usage:
 
 ```javascript
-<RichToolbar getEditor={() => this.richtext}/>
+<RichToolbar getEditor={() => this.richtext} />
+```
+
+#### With Custom Action:
+
+To define your own custom action:
+
+-   Send your action name as string in the `actions` array.
+-   Include an icon for it with the `iconMap`
+-   Add a function prop with the same action name to be called on tap
+
+```javascript
+<RichToolbar
+	getEditor={() => this.richtext}
+		actions={[
+			actions.setBold,
+			actions.setItalic,s
+			actions.insertBulletsList,
+			actions.insertOrderedList,
+			actions.insertImage,
+			'customAction',
+		]}
+		iconMap={{
+			customAction: customIcon,
+		}}
+		customAction={this.handleCustomAction}
+/>
 ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # React Native Pell Rich Text Editor
 
+
 [![NPM](https://img.shields.io/npm/v/react-native-pell-rich-editor.svg)](https://www.npmjs.com/package/react-native-pell-rich-editor)
 
----
+------
 
 > A fully functional Rich Text Editor for both Android and iOS
 
@@ -14,111 +15,115 @@ npm i react-native-pell-rich-editor
 
 Also, follow instructions [here](https://github.com/react-native-community/react-native-webview) to add the native `react-native-webview` dependency.
 
--   [Example](./examples)
+* [Example](./examples)
 
 ## `RichEditor`
-
 The editor component. Simply place this component in your view hierarchy to receive a fully functional Rich text Editor.
 
 `RichEditor` takes the following optional props:
 
--   `placeholder`
+* `placeholder`
 
     Wrap the editor content placeholder
 
--   `initialContentHTML`
+* `initialContentHTML`
 
-        	HTML that will be rendered in the content section on load.
+  HTML that will be rendered in the content section on load.
 
--   `editorInitializedCallback`
+* `editorInitializedCallback `
 
-        	A function that will be called when the editor has been initialized.
+  A function that will be called when the editor has been initialized.
 
--   `editorStyle`
+* `editorStyle`
 
-        	Styling for container or for Rich Editor more dark or light settings
+  Styling for container or for Rich Editor more dark or light settings
 
--   `useContainer`
+* `useContainer`
 
-        	A boolean value that determines if a View container is wrapped around the WebView. The default value is true. If you are using your own View to wrap this library around, set this value to false.
+  A boolean value that determines if a View container is wrapped around the WebView. The default value is true. If you are using your own View to wrap this library around, set this value to false. 
 
-`RichEditor` also has methods that can be used on its `ref` to set:
+  
 
--   `setContentHTML(html:string)`
--   `insertImage(url:string)`
--   `setContentFocusHandler(handler: Function)`
--   `blurContentEditor()`
--   `focusContentEditor()`
+`RichEditor` also has methods that can be used on its `ref` to  set:
+
+*  `setContentHTML(html:string)`
+*  `insertImage(url:string) `
+*  `setContentFocusHandler(handler: Function)`
+*  `blurContentEditor()`
+*  `focusContentEditor()`
 
 This method registers a function that will get called whenver the cursor position changes or a change is made to the styling of the editor at the cursor's position., The callback will be called with an array of `actions` that are active at the cusor position, allowing a toolbar to respond to changes.
 
--   `registerToolbar(listener: Function)`
+*  `registerToolbar(listener: Function)` 
+
+
 
 ### Example Usage:
 
 ```javascript
 <RichEditor
-    ref={(r) => (this.richtext = r)}
-    initialContentHTML={'Hello <b>World</b> <p>this is a new paragraph</p> <p>this is another new paragraph</p>'}
-    editorInitializedCallback={() => this.onEditorInitialized()}
+  ref={(r) => this.richtext = r}
+  initialContentHTML={'Hello <b>World</b> <p>this is a new paragraph</p> <p>this is another new paragraph</p>'}
+  editorInitializedCallback={() => this.onEditorInitialized()}
 />
 ```
 
 ![](readme/editor.jpg)
 
+
 ## `RichToolbar`
 
 This is a Component that provides a toolbar for easily controlling an editor. It is designed to be used together with a `RichEditor` component.
 
-The `RichToolbar` has one required property:
+The `RichToolbar` has one required property: 
 
--   `getEditor()`
+* `getEditor()`
 
-Which must provide a **function** that returns a `ref` to a `RichEditor` component.
+Which must provide a **function** that returns a `ref` to a `RichEditor` component. 
 
 This is because the `ref` is not created until after the first render, before which the toolbar is rendered. This means that any `ref` passed directly will inevitably be passed as `undefined`.
 
 Other props supported by the `RichToolbar` component are:
 
--   `actions`
+* `actions`
 
-        	An `array` of `actions` to be provided by this toolbar. The default actions are:
-        	* `actions.insertImage`
-        * `actions.setBold`
-        * `actions.setItalic`
-        * `actions.insertBulletsList`
-        * `actions.insertOrderedList`
-        * `actions.insertLink`
+	An `array` of `actions` to be provided by this toolbar. The default actions are: 
+	* `actions.insertImage`
+  	* `actions.setBold`
+  	* `actions.setItalic`
+  	* `actions.insertBulletsList`
+  	* `actions.insertOrderedList`
+  	* `actions.insertLink`
+  
+* `onPressAddImage`
 
--   `onPressAddImage`
-
-    Functions called when the `addImage` actions are tapped.
-
--   `selectedButtonStyle`
--   `iconTint`
--   `selectedIconTint`
--   `unselectedButtonStyle`
-
+    Functions called when the `addImage` actions are tapped. 
+    
+* `selectedButtonStyle`
+* `iconTint`
+* `selectedIconTint`
+* `unselectedButtonStyle`
+  
     These provide options for styling action buttons.
 
--   `iconSize`
-
+* `iconSize`
+  
     Defines the size of the icon in pixels. Default is 50.
 
--   `renderAction`
+* `renderAction`
 
-        	Altenatively, you can provide a render function that will be used instead of the default, so you can fully control the tollbar design.
+  Altenatively, you can provide a render function that will be used instead of the default, so you can fully control the tollbar design.
 
--   `iconMap`
+* `iconMap` 
 
-        	`RichTextToolbar` comes with default icons for the default actions it renders. To override those, or to add icons for non-default actions, provide them in a dictionary to this prop.
-
+	`RichTextToolbar` comes with default icons for the default actions it renders. To override those, or to add icons for non-default actions, provide them in a dictionary to this prop.
+	
+	
 ### Example Usage:
 
 ```javascript
-<RichToolbar getEditor={() => this.richtext} />
+<RichToolbar getEditor={() => this.richtext}/>
 ```
-
 #### With Custom Action:
 
 To define your own custom action:

--- a/README.md
+++ b/README.md
@@ -28,22 +28,21 @@ The editor component. Simply place this component in your view hierarchy to rece
 
 * `initialContentHTML`
 
-  HTML that will be rendered in the content section on load.
+	HTML that will be rendered in the content section on load.
 
 * `editorInitializedCallback `
 
-  A function that will be called when the editor has been initialized.
-
+	A function that will be called when the editor has been initialized.
+	
 * `editorStyle`
 
-  Styling for container or for Rich Editor more dark or light settings
+	Styling for container or for Rich Editor more dark or light settings
 
 * `useContainer`
 
-  A boolean value that determines if a View container is wrapped around the WebView. The default value is true. If you are using your own View to wrap this library around, set this value to false. 
-
-  
-
+	A boolean value that determines if a View container is wrapped around the WebView. The default value is true. If you are using your own View to wrap this library around, set this value to false. 
+	
+	
 `RichEditor` also has methods that can be used on its `ref` to  set:
 
 *  `setContentHTML(html:string)`
@@ -94,26 +93,27 @@ Other props supported by the `RichToolbar` component are:
   	* `actions.insertBulletsList`
   	* `actions.insertOrderedList`
   	* `actions.insertLink`
-  
+  	
 * `onPressAddImage`
 
     Functions called when the `addImage` actions are tapped. 
-    
+        
 * `selectedButtonStyle`
 * `iconTint`
 * `selectedIconTint`
 * `unselectedButtonStyle`
-  
+    
     These provide options for styling action buttons.
 
 * `iconSize`
-  
+    
     Defines the size of the icon in pixels. Default is 50.
 
 * `renderAction`
 
-  Altenatively, you can provide a render function that will be used instead of the default, so you can fully control the tollbar design.
-
+	Altenatively, you can provide a render function that will be used instead of the default, so you can fully control the tollbar design.
+	
+	
 * `iconMap` 
 
 	`RichTextToolbar` comes with default icons for the default actions it renders. To override those, or to add icons for non-default actions, provide them in a dictionary to this prop.
@@ -124,6 +124,7 @@ Other props supported by the `RichToolbar` component are:
 ```javascript
 <RichToolbar getEditor={() => this.richtext}/>
 ```
+
 #### With Custom Action:
 
 To define your own custom action:

--- a/src/RichToolbar.js
+++ b/src/RichToolbar.js
@@ -141,6 +141,11 @@ export default class RichToolbar extends Component {
                     this.props.onPressAddImage();
                 }
                 break;
+            default:
+                if (this.props[action]) {
+                    this.props[action]();
+                }
+                break;
         }
     }
 


### PR DESCRIPTION
Allow using custom icon/actions on the toolbar.
The proposed solution uses a minimal change on the code, that allows adding as many new actions as needed.

For every custom action it needs to be defined the following items;
- Action string on `actions` array
- Action icon within `iconMap`
- Action handler as a new Prop using same name defined on the array

Example of usage:

```javascript
<RichToolbar
  editor={richText}
  getEditor={() => richText.current}
  actions={[
    actions.setBold, 
    actions.setItalic,
    actions.insertBulletsList,
    actions.insertOrderedList,
    actions.insertImage,
    emojiAction,
  ]}
  iconMap={{
    [emojiAction]: emojiIcon,
  }}
  insertEmoji={openEmoji}
/>
```


related issues: https://github.com/stulip/react-native-pell-rich-editor/issues/9