### PR TITLE
Editor fix height

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,12 @@ The editor component. Simply place this component in your view hierarchy to rece
 	
 * `editorStyle`
 
-	Styling for container or for Rich Editor more dark or light settings
+	Styling for container or for Rich Editor more dark or light settings. Object containing the following options:
+
+	- `backgroundColor`: Editor background color
+	- `color`: Editor text color
+	- `placeholderColor`: Editor placeholder text color
+	- `contentHeight`: Height for the Content editor (defaults to `100%`)
 
 * `useContainer`
 

--- a/src/RichEditor.js
+++ b/src/RichEditor.js
@@ -31,9 +31,9 @@ export default class RichTextEditor extends Component {
         that.setRef = that.setRef.bind(that);
         that.isInit = false;
         that.selectionChangeListeners = [];
-        const {editorStyle: {backgroundColor, color, placeholderColor} = {}, html} = props;
+        const {editorStyle: {backgroundColor, color, placeholderColor, contentHeight} = {}, html} = props;
         that.state = {
-            html: {html: html || createHTML({backgroundColor, color, placeholderColor})},
+            html: {html: html || createHTML({backgroundColor, color, placeholderColor, contentHeight})},
             keyboardHeight: 0,
             height: 0,
         };

--- a/src/editor.js
+++ b/src/editor.js
@@ -1,7 +1,7 @@
 //console.log = function (){ postAction({type: 'LOG', data: Array.prototype.slice.call(arguments)});};
 
 function createHTML(options = {}) {
-    const {backgroundColor = '#FFF', color = '#000033', placeholderColor = '#a9a9a9'} = options;
+    const {backgroundColor = '#FFF', color = '#000033', placeholderColor = '#a9a9a9', contentHeight = '100%'} = options;
     return `
 <!DOCTYPE html>
 <html>
@@ -14,7 +14,7 @@ function createHTML(options = {}) {
         img {max-width: 98%;margin-left:auto;margin-right:auto;display: block;}
         .content {font-family: Arial, Helvetica, sans-serif;color: ${color}; width: 100%;height: 100%;-webkit-overflow-scrolling: touch;padding-left: 0;padding-right: 0;}
         .pell { height: 100%;}
-        .pell-content { outline: 0; overflow-y: auto;padding: 10px;height: 100%;}
+        .pell-content { outline: 0; overflow-y: auto;padding: 10px;height: ${contentHeight};}
         table {width: 100% !important;}
         table td {width: inherit;}
         table span { font-size: 12px !important; }


### PR DESCRIPTION
While integrating the editor on my application I needed to define the height of the editor content at a reduce space but allow to have a long text with scroll properties. I have tried some of the comments found around in the issues but not managed to work until I made these changes to provide myself with an initial height.

If there are any other alternatives to achieve the same behaviour, please point that out and ignore this PR.